### PR TITLE
Gesdiscumu 5213 update policy

### DIFF
--- a/gap_detection_module/lambda.tf
+++ b/gap_detection_module/lambda.tf
@@ -115,7 +115,7 @@ resource "aws_iam_role_policy" "lambda_rds_proxy_role_policy" {
   })
 }
 
-resource "aws_iam_role_policy" "lambda_sns_get_attributes" {
+resource "aws_iam_role_policy" "lambda_sns_get_and_set_attributes" {
   name = "${var.DEPLOY_NAME}-gap-detection-sns-filter"
   role = var.lambda_processing_role_name
    policy = jsonencode({

--- a/gap_detection_module/lambda.tf
+++ b/gap_detection_module/lambda.tf
@@ -118,18 +118,13 @@ resource "aws_iam_role_policy" "lambda_rds_proxy_role_policy" {
 resource "aws_iam_role_policy" "lambda_sns_get_and_set_attributes" {
   name = "${var.DEPLOY_NAME}-gap-detection-sns-filter"
   role = var.lambda_processing_role_name
-   policy = jsonencode({
+  policy = jsonencode({
     Version = "2012-10-17",
     Statement = [{
       Effect = "Allow",
-      Action = [
-				"sns:SetSubscriptionAttributes",
-				"sns:GetSubscriptionAttributes"
-			],
-      Resource = [
-  aws_sns_topic_subscription.report_granules_ingest_subscription.arn,
-  aws_sns_topic_subscription.report_granules_deletion_subscription.arn
-]
+      Action = ["sns:SetSubscriptionAttributes", "sns:GetSubscriptionAttributes"],
+      Resource = [aws_sns_topic_subscription.report_granules_ingest_subscription.arn, aws_sns_topic_subscription.report_granules_deletion_subscription.arn
+      ]
     }]
   })
 

--- a/gap_detection_module/lambda.tf
+++ b/gap_detection_module/lambda.tf
@@ -115,6 +115,26 @@ resource "aws_iam_role_policy" "lambda_rds_proxy_role_policy" {
   })
 }
 
+resource "aws_iam_role_policy" "lambda_sns_get_attributes" {
+  name = "${var.DEPLOY_NAME}-gap-detection-sns-filter"
+  role = var.lambda_processing_role_name
+   policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Action = [
+				"sns:SetSubscriptionAttributes",
+				"sns:GetSubscriptionAttributes"
+			],
+      Resource = [
+  aws_sns_topic_subscription.report_granules_ingest_subscription.arn,
+  aws_sns_topic_subscription.report_granules_deletion_subscription.arn
+]
+    }]
+  })
+
+}
+
 # Allow lambda role to read RDS secrets from secrets manager
 resource "aws_iam_role_policy" "lambda_rds_secret_policy" {
   name = "${var.DEPLOY_NAME}-gap-detection-rds-secret-policy"


### PR DESCRIPTION
Updating lambda.tf to add policy to allow gapConfig to get sns subscription attributes. 

Link to ticket: https://bugs.earthdata.nasa.gov/browse/GESDISCUMU-5213