### PR TITLE
GESDISCUMU-5221 removed problematic check constraint

### DIFF
--- a/src/shared/gap_schema.sql
+++ b/src/shared/gap_schema.sql
@@ -21,7 +21,6 @@ CREATE TABLE gaps (
     -- Basic checks on timestamps
     CHECK (start_ts < end_ts),
     CHECK (start_ts != end_ts),
-    CHECK (end_ts - start_ts >= INTERVAL '1 second'),
 
     -- Unique constraint 
     CONSTRAINT no_duplicate_intervals


### PR DESCRIPTION
Removes constraint responsible for failures on certain collections with gaps in the 1-2 second range. Jira link: https://bugs.earthdata.nasa.gov/browse/GESDISCUMU-5221