### PR TITLE
GESDISCUMU-5240-Update-the-gapReporter-lambda-to-handle-large-responses-from-fetch-time-gaps-function

### DIFF
--- a/gap_detection_module/main.tf
+++ b/gap_detection_module/main.tf
@@ -42,7 +42,8 @@ locals {
       }
     }
     gapReporter = {
-      timeout = 900
+      timeout     = 900
+      memory_size = 512
       variables = {
         RDS_SECRET        = aws_secretsmanager_secret.rds_admin_login.name
         RDS_PROXY_HOST    = aws_db_proxy.rds_proxy.endpoint


### PR DESCRIPTION
Increase gapReporter Lambda memory to 512 MB. 

Fixes memory issue causing missing s3 uploads for collections with many gaps