### PR TITLE
Remove trailing comma in gapReporter csv

### DIFF
--- a/src/gapReporter/gapReporter.py
+++ b/src/gapReporter/gapReporter.py
@@ -74,7 +74,7 @@ def lambda_handler(event, context):
                 with open(output_csv, 'w', newline='') as csvfile:
                     csvwriter = csv.writer(csvfile)
                     csvwriter.writerow(['gap_begin', 'gap_end'])
-                    csvwriter.writerows(time_gaps)
+                    csvwriter.writerows([(row[0], row[1]) for row in time_gaps])
 
                 # Upload to S3
                 s3 = boto3.client('s3')


### PR DESCRIPTION
Changed gapReporter to only use the first two columns of fetch_time_gaps response to remove the trailing comma in the csv reports. 

fetch_time_gaps is unchanged and gapReporter will never use the reasons column so this will not change any other functionality. 