### PR TITLE
Fix/allow policy scope

### DIFF
--- a/src/authorizer/authorizer.go
+++ b/src/authorizer/authorizer.go
@@ -125,17 +125,15 @@ func initJWKS() *keyfunc.JWKS {
 
 // Generate resource policy for a given resource and effect (ie. Allow or Deny)
 func generatePolicy(effect, message, userID, role string, event events.APIGatewayCustomAuthorizerRequestTypeRequest) events.APIGatewayCustomAuthorizerResponse {
+	sourceIP, _, _ := strings.Cut(event.Headers["CloudFront-Viewer-Address"], ":")
 	logger.Info(message,
 		zap.String("effect", effect),
 		zap.String("user", userID),
 		zap.String("role", role),
-		zap.String("source_ip", event.RequestContext.Identity.SourceIP),
+		zap.String("source_ip", sourceIP),
 		zap.String("method", event.HTTPMethod),
 		zap.String("path", event.Path),
 	)
-	//if effect == "Deny" {
-	//	event.MethodArn = "*"
-	//}
 	return events.APIGatewayCustomAuthorizerResponse{
 		PrincipalID: "user",
 		PolicyDocument: events.APIGatewayCustomAuthorizerPolicy{
@@ -143,7 +141,6 @@ func generatePolicy(effect, message, userID, role string, event events.APIGatewa
 			Statement: []events.IAMPolicyStatement{{
 				Action:   []string{"execute-api:Invoke"},
 				Effect:   effect,
-				//Resource: []string{event.MethodArn},
 				Resource: []string{"*"},
 			}},
 		},

--- a/src/authorizer/authorizer.go
+++ b/src/authorizer/authorizer.go
@@ -133,9 +133,9 @@ func generatePolicy(effect, message, userID, role string, event events.APIGatewa
 		zap.String("method", event.HTTPMethod),
 		zap.String("path", event.Path),
 	)
-	if effect == "Deny" {
-		event.MethodArn = "*"
-	}
+	//if effect == "Deny" {
+	//	event.MethodArn = "*"
+	//}
 	return events.APIGatewayCustomAuthorizerResponse{
 		PrincipalID: "user",
 		PolicyDocument: events.APIGatewayCustomAuthorizerPolicy{
@@ -143,7 +143,8 @@ func generatePolicy(effect, message, userID, role string, event events.APIGatewa
 			Statement: []events.IAMPolicyStatement{{
 				Action:   []string{"execute-api:Invoke"},
 				Effect:   effect,
-				Resource: []string{event.MethodArn},
+				//Resource: []string{event.MethodArn},
+				Resource: []string{"*"},
 			}},
 		},
 	}

--- a/src/authorizer/authorizer_test.go
+++ b/src/authorizer/authorizer_test.go
@@ -145,7 +145,7 @@ func TestGeneratePolicy(t *testing.T) {
 					Statement: []events.IAMPolicyStatement{{
 						Action:   []string{"execute-api:Invoke"},
 						Effect:   "Allow",
-						Resource: []string{testMethodArn},
+     					Resource: []string{"*"},
 					}},
 				},
 			},


### PR DESCRIPTION
When re-using the same credential in requests for distinct methods in the same authorization tier, the subsequent requests will always be denied without invoking the authorizer lambda. This is because the current authorizer policies are strictly scoped to the requested method, resulting in the cached verdict only matching the initially requested method. 

This PR resolves this by returning `Resource: ["*"]` instead of strictly the one that was requested, matching the current Deny behavior and ensuring that requests that hit the authorization cache receive the correct verdict regardless of method. Because admin and public methods have separate authorization caches, there is no risk of a public identity using a cached verdict to access admin-level methods.