### PR TITLE
add collection_id exclusion to subscription filter

### DIFF
--- a/gap_detection_module/sns.tf
+++ b/gap_detection_module/sns.tf
@@ -48,7 +48,7 @@ resource "aws_sns_topic_subscription" "report_granules_ingest_subscription" {
   topic_arn = var.report_granules_topic_arn
   protocol = "sqs"
   endpoint = aws_sqs_queue.gap_detection_ingest_queue.arn
-  filter_policy = jsonencode({
+  filter_policy = jsonencode(merge({
     "record.status" = [
       "completed"
     ],
@@ -64,6 +64,12 @@ resource "aws_sns_topic_subscription" "report_granules_ingest_subscription" {
         prefix = prefix
       }
     ]
-  })
+  },
+    length(var.excluded_collection_id_prefixes) > 0 ? {
+      "record.collectionId" = [
+        { "anything-but" = { prefix = var.excluded_collection_id_prefixes[0] } }
+      ]
+    } : {}
+  ))
   filter_policy_scope = "MessageBody"
 }

--- a/gap_detection_module/variables.tf
+++ b/gap_detection_module/variables.tf
@@ -155,3 +155,9 @@ variable "authorized_hosts" {
   description = "List of IP addresses of hosts that have read-only authorization without authentication"
   default     = []
 }
+
+variable "excluded_collection_id_prefixes" {
+  type        = list(string)
+  description = "Collection ID prefixes to exclude from ingest subscription"
+  default     = []
+}


### PR DESCRIPTION
Adds excluded_collection_id_prefixes to module variables which is used in the report-granules topic subscription filter